### PR TITLE
Fix incorrect variable value

### DIFF
--- a/app/code/community/Gene/Braintree/Block/Js.php
+++ b/app/code/community/Gene/Braintree/Block/Js.php
@@ -291,7 +291,7 @@ class Gene_Braintree_Block_Js extends Gene_Braintree_Block_Assets
             $disallowed[] = "'elv'";
         }
 
-        $return = '';
+        $return = [];
         if ($disallowed) {
             $return[] = 'disallowed: [' . implode(",", $disallowed) . ']';
         } else {


### PR DESCRIPTION
$return is supposed to be initialised as an array

With this issue in place, the form is not rendered in checkout, and loading spinner stays active

![image](https://user-images.githubusercontent.com/4994260/212448660-271edac8-27d6-425f-96be-f80dd04edb82.png)

```
Fatal error: Uncaught Error: [] operator not supported for strings in /vagrant/sites/ntotank/app/code/community/Gene/Braintree/Block/Js.php:298
Stack trace:
#0 /vagrant/sites/ntotank/app/design/frontend/base/default/template/gene/braintree/js/setup.phtml(54): Gene_Braintree_Block_Js->getFunding()
https://github.com/uptactics/ntotank/pull/1 /vagrant/sites/ntotank/app/code/core/Mage/Core/Block/Template.php(263): include('/vagrant/sites/...')
https://github.com/uptactics/ntotank/pull/2 /vagrant/sites/ntotank/app/code/core/Mage/Core/Block/Template.php(294): Mage_Core_Block_Template->fetchView()
https://github.com/uptactics/ntotank/pull/3 /vagrant/sites/ntotank/app/code/core/Mage/Core/Block/Template.php(308): Mage_Core_Block_Template->renderView()
https://github.com/uptactics/ntotank/pull/4 /vagrant/sites/ntotank/app/code/community/Gene/Braintree/Block/Assets.php(235): Mage_Core_Block_Template->_toHtml()
https://github.com/uptactics/ntotank/pull/5 /vagrant/sites/ntotank/app/code/community/Gene/Braintree/Block/Js.php(253): Gene_Braintree_Block_Assets->_toHtml()
https://github.com/uptactics/ntotank/pull/6 /vagrant/sites/ntotank/app/code/core/Mage/Core/Block/Abstract.php(938): Gene_Braintree_Block_Js->_toHtml()
https://github.com/uptactics/ntotank/pull/7 /vagrant/sites/ntotank/app/code/core/Mage/Core/Block/Text in /vagrant/sites/ntotank/app/code/community/Gene/Braintree/Block/Js.php on line 298
```